### PR TITLE
group under jax.rs suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,24 +4,14 @@ This is an implementation of a JAX-RS Services whiteboard [OSGi RFC-217](https:/
 
 ## Building
 
-Execute the usual maven task `mvn package`.
+Execute the maven tasks `mvn clean install`.
 
 ## Running the Example
 
-This is a two step process.
+The file `jax-rs.example-run/example.jar` should have been created.
 
-### Create the executable jar
-
-In the bndrun subdirectory, execute the task `mvn bnd-export:export`
-
-**Note:** There's an occasional NPE occuring during the resolve operation. If you should encounter this, please try again.
-
-### Run the exported jar
-
-Once exported, the bndrun directory should contain a file `org.apache.aries.jax-rs.example.jar`.
-
-Execute the following command
+Execute the following command:
 
 ```
-java -jar org.apache.aries.jax-rs.example.jar
+java -jar jax-rs.example-run/example.jar
 ```

--- a/jax-rs.example-run/example.bndrun
+++ b/jax-rs.example-run/example.bndrun
@@ -12,6 +12,7 @@
 
 -runrequires: \
 	osgi.identity;filter:='(osgi.identity=org.apache.aries.jax.rs.example)',\
+	osgi.identity;filter:='(osgi.identity=org.apache.aries.jax.rs.log4j-configuration)',\
 	osgi.identity;filter:='(osgi.identity=org.apache.felix.gogo.jline)'
 
    # ,\
@@ -19,28 +20,38 @@
 
 -runfw: org.eclipse.osgi;version='[3.10.100.v20150529-1857,3.10.100.v20150529-1857]'
 -runbundles: \
-	javax.annotation-api;version='[1.2.0,1.2.1)',\
-	javax.json-api;version='[1.0.0,1.0.1)',\
-	javax.ws.rs-api;version='[2.0.1,2.0.2)',\
-	log4j;version='[1.2.17,1.2.18)',\
-	org.apache.aries.jax.rs.example;version='[1.0.0,1.0.1)',\
-	org.apache.aries.jax.rs.whiteboard;version='[1.0.0,1.0.1)',\
-	org.apache.felix.configadmin;version='[1.8.8,1.8.9)',\
-	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
-	org.apache.felix.scr;version='[2.0.2,2.0.3)',\
-	org.apache.ws.xmlschema.core;version='[2.2.1,2.2.2)',\
-	org.eclipse.equinox.event;version='[1.3.100,1.3.101)',\
-	org.eclipse.equinox.metatype;version='[1.4.100,1.4.101)',\
-	org.objectweb.asm;version='[5.0.4,5.0.5)',\
-	org.osgi.service.event;version='[1.3.1,1.3.2)',\
-	org.osgi.service.metatype;version='[1.3.0,1.3.1)',\
-	slf4j.api;version='[1.7.21,1.7.22)',\
+	javax.annotation-api; version='[1.2.0,1.2.1)',\
+	javax.json-api; version='[1.0.0,1.0.1)',\
+	javax.ws.rs-api; version='[2.0.1,2.0.2)',\
+	log4j; version='[1.2.17,1.2.18)',\
+	org.apache.aries.jax.rs.example; version='[1.0.0,1.0.1)',\
+	org.apache.aries.jax.rs.log4j-configuration; version='[1.0.0,1.0.1)',\
+	org.apache.aries.jax.rs.whiteboard; version='[1.0.0,1.0.1)',\
+	org.apache.felix.bundlerepository; version='[1.6.0,1.6.1)',\
+	org.apache.felix.configadmin; version='[1.8.8,1.8.9)',\
+	org.apache.felix.gogo.command; version='[1.0.0,1.0.1)',\
+	org.apache.felix.gogo.jline; version='[1.0.0,1.0.1)',\
+	org.apache.felix.gogo.runtime; version='[1.0.0,1.0.1)',\
+	org.apache.felix.http.api; version='[3.0.0,3.0.1)',\
+	org.apache.felix.http.jetty; version='[3.4.0,3.4.1)',\
+	org.apache.felix.http.servlet-api; version='[1.1.2,1.1.3)',\
+	org.apache.felix.scr; version='[2.0.2,2.0.3)',\
+	org.apache.ws.xmlschema.core; version='[2.2.1,2.2.2)',\
+	org.eclipse.equinox.event; version='[1.3.100,1.3.101)',\
+	org.eclipse.equinox.metatype; version='[1.4.100,1.4.101)',\
+	org.jline; version='[3.0.0,3.0.1)',\
+	org.objectweb.asm; version='[5.0.4,5.0.5)',\
+	org.osgi.service.event; version='[1.3.1,1.3.2)',\
+	org.osgi.service.metatype; version='[1.3.0,1.3.1)',\
+	slf4j.api; version='[1.7.21,1.7.22)',\
 	slf4j.log4j12;version='[1.6.1,1.6.2)'
 
 -runee: JavaSE-1.8
 -resolve.effective: resolve, active
--runproperties.eqnx: \
+-runproperties: \
 	osgi.console.enable.builtin=false, \
 	osgi.console=, \
 	org.osgi.service.http.port=8080
 -runsystemcapabilities.dflt: ${native_capability}
+-runblacklist:\
+	osgi.identity;filter:='(osgi.identity=org.osgi.compendium)'

--- a/jax-rs.example-run/example.bndrun
+++ b/jax-rs.example-run/example.bndrun
@@ -24,9 +24,9 @@
 	javax.json-api; version='[1.0.0,1.0.1)',\
 	javax.ws.rs-api; version='[2.0.1,2.0.2)',\
 	log4j; version='[1.2.17,1.2.18)',\
-	org.apache.aries.jax.rs.example; version='[1.0.0,1.0.1)',\
-	org.apache.aries.jax.rs.log4j-configuration; version='[1.0.0,1.0.1)',\
-	org.apache.aries.jax.rs.whiteboard; version='[1.0.0,1.0.1)',\
+	org.apache.aries.jax.rs.example; version='[0.0.1,0.0.2)',\
+	org.apache.aries.jax.rs.log4j-configuration; version='[0.0.1,0.0.2)',\
+	org.apache.aries.jax.rs.whiteboard; version='[0.0.1,0.0.2)',\
 	org.apache.felix.bundlerepository; version='[1.6.0,1.6.1)',\
 	org.apache.felix.configadmin; version='[1.8.8,1.8.9)',\
 	org.apache.felix.gogo.command; version='[1.0.0,1.0.1)',\

--- a/jax-rs.example-run/pom.xml
+++ b/jax-rs.example-run/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 	    <groupId>org.apache.aries</groupId>
 	    <artifactId>org.apache.aries.jax.rs</artifactId>
-	    <version>1.0.0-SNAPSHOT</version>
+	    <version>0.0.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.apache.aries.jax.rs.example-run</artifactId>
@@ -40,7 +40,7 @@
 		<dependency>
 			<groupId>org.apache.aries</groupId>
 			<artifactId>org.apache.aries.jax.rs.example</artifactId>
-			<version>1.0.0-SNAPSHOT</version>
+			<version>0.0.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.aries</groupId>
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.apache.aries</groupId>
 			<artifactId>org.apache.aries.jax.rs.whiteboard</artifactId>
-			<version>1.0.0-SNAPSHOT</version>
+			<version>0.0.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.felix</groupId>

--- a/jax-rs.example-run/pom.xml
+++ b/jax-rs.example-run/pom.xml
@@ -20,7 +20,7 @@
 				<version>3.4.0-SNAPSHOT</version>
 				<configuration>
 					<failOnChanges>false</failOnChanges>
-					<resolve>true</resolve>
+					<resolve>false</resolve>
 					<bndruns>
 						<bndrun>example.bndrun</bndrun>
 					</bndruns>
@@ -40,6 +40,11 @@
 		<dependency>
 			<groupId>org.apache.aries</groupId>
 			<artifactId>org.apache.aries.jax.rs.example</artifactId>
+			<version>1.0.0-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.aries</groupId>
+			<artifactId>org.apache.aries.jax.rs.log4j-configuration</artifactId>
 			<version>1.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>

--- a/jax-rs.example-run/pom.xml
+++ b/jax-rs.example-run/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-	    <groupId>org.apache.aries</groupId>
+	    <groupId>org.apache.aries.jax.rs</groupId>
 	    <artifactId>org.apache.aries.jax.rs</artifactId>
 	    <version>0.0.1-SNAPSHOT</version>
 	</parent>
@@ -40,17 +40,17 @@
 	</build>
 	<dependencies>
 		<dependency>
-			<groupId>org.apache.aries</groupId>
+			<groupId>org.apache.aries.jax.rs</groupId>
 			<artifactId>org.apache.aries.jax.rs.example</artifactId>
 			<version>0.0.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.aries</groupId>
+			<groupId>org.apache.aries.jax.rs</groupId>
 			<artifactId>org.apache.aries.jax.rs.log4j-configuration</artifactId>
 			<version>0.0.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.aries</groupId>
+			<groupId>org.apache.aries.jax.rs</groupId>
 			<artifactId>org.apache.aries.jax.rs.whiteboard</artifactId>
 			<version>0.0.1-SNAPSHOT</version>
 		</dependency>

--- a/jax-rs.example-run/pom.xml
+++ b/jax-rs.example-run/pom.xml
@@ -9,8 +9,10 @@
 	</parent>
 
 	<artifactId>org.apache.aries.jax.rs.example-run</artifactId>
-
+	<description>Apache Aries JAX-RS Example Run Configuration</description>
+	<name>Apache Aries JAX-RS Example Run Configuration</name>
 	<packaging>pom</packaging>
+	<version>0.0.1-SNAPSHOT</version>
 
 	<build>
 		<plugins>
@@ -45,7 +47,7 @@
 		<dependency>
 			<groupId>org.apache.aries</groupId>
 			<artifactId>org.apache.aries.jax.rs.log4j-configuration</artifactId>
-			<version>1.0.0-SNAPSHOT</version>
+			<version>0.0.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.aries</groupId>

--- a/jax-rs.example/pom.xml
+++ b/jax-rs.example/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.apache.aries</groupId>
         <artifactId>org.apache.aries.jax.rs</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>org.apache.aries.jax.rs.example</artifactId>
     <packaging>jar</packaging>

--- a/jax-rs.example/pom.xml
+++ b/jax-rs.example/pom.xml
@@ -5,7 +5,7 @@
 >
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.apache.aries</groupId>
+        <groupId>org.apache.aries.jax.rs</groupId>
         <artifactId>org.apache.aries.jax.rs</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>

--- a/jax-rs.example/pom.xml
+++ b/jax-rs.example/pom.xml
@@ -9,9 +9,12 @@
         <artifactId>org.apache.aries.jax.rs</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
+
     <artifactId>org.apache.aries.jax.rs.example</artifactId>
-    <packaging>jar</packaging>
     <description>Apache Aries JAX-RS Example</description>
+    <name>Apache Aries JAX-RS Example</name>
+    <version>0.0.1-SNAPSHOT</version>
+
     <dependencies>
         <dependency>
             <groupId>javax.ws.rs</groupId>

--- a/jax-rs.itests-run/itest.bndrun
+++ b/jax-rs.itests-run/itest.bndrun
@@ -30,9 +30,9 @@
   javax.json-api; version='[1.0.0,1.0.1)',\
   javax.ws.rs-api; version='[2.0.1,2.0.2)',\
   log4j; version='[1.2.17,1.2.18)',\
-  org.apache.aries.jax.rs.itests; version='[1.0.0,1.0.1)',\
-  org.apache.aries.jax.rs.log4j-configuration; version='[1.0.0,1.0.1)',\
-  org.apache.aries.jax.rs.whiteboard; version='[1.0.0,1.0.1)',\
+  org.apache.aries.jax.rs.itests; version='[0.0.1,0.0.2)',\
+  org.apache.aries.jax.rs.log4j-configuration; version='[0.0.1,0.0.2)',\
+  org.apache.aries.jax.rs.whiteboard; version='[0.0.1,0.0.2)',\
   org.apache.felix.bundlerepository; version='[1.6.0,1.6.1)',\
   org.apache.felix.configadmin; version='[1.8.8,1.8.9)',\
   org.apache.felix.http.api; version='[3.0.0,3.0.1)',\

--- a/jax-rs.itests-run/itest.bndrun
+++ b/jax-rs.itests-run/itest.bndrun
@@ -9,7 +9,8 @@
     location=${.}/target/cached.xml
 
 -runrequires: \
-    osgi.identity;filter:='(osgi.identity=org.apache.aries.jax.rs.itests)'
+    osgi.identity;filter:='(osgi.identity=org.apache.aries.jax.rs.itests)',\
+    osgi.identity;filter:='(osgi.identity=org.apache.aries.jax.rs.log4j-configuration)'
 
 -runfw: org.eclipse.osgi;version='[3.10.100.v20150529-1857,3.10.100.v20150529-1857]'
 
@@ -20,7 +21,7 @@
   
 -runsystempackages.eqnx: javax.script
 -runsystemcapabilities.dflt: ${native_capability}
--runproperties.eqnx:        \
+-runproperties: \
   osgi.console.enable.builtin=false, \
   osgi.console=, \
   org.osgi.service.http.port=8080
@@ -30,6 +31,7 @@
   javax.ws.rs-api; version='[2.0.1,2.0.2)',\
   log4j; version='[1.2.17,1.2.18)',\
   org.apache.aries.jax.rs.itests; version='[1.0.0,1.0.1)',\
+  org.apache.aries.jax.rs.log4j-configuration; version='[1.0.0,1.0.1)',\
   org.apache.aries.jax.rs.whiteboard; version='[1.0.0,1.0.1)',\
   org.apache.felix.bundlerepository; version='[1.6.0,1.6.1)',\
   org.apache.felix.configadmin; version='[1.8.8,1.8.9)',\

--- a/jax-rs.itests-run/pom.xml
+++ b/jax-rs.itests-run/pom.xml
@@ -47,6 +47,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.aries</groupId>
+			<artifactId>org.apache.aries.jax.rs.log4j-configuration</artifactId>
+			<version>1.0.0-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.aries</groupId>
 			<artifactId>org.apache.aries.jax.rs.whiteboard</artifactId>
 			<version>1.0.0-SNAPSHOT</version>
 		</dependency>

--- a/jax-rs.itests-run/pom.xml
+++ b/jax-rs.itests-run/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.apache.aries</groupId>
 		<artifactId>org.apache.aries.jax.rs</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>0.0.1-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>org.apache.aries</groupId>
 			<artifactId>org.apache.aries.jax.rs.itests</artifactId>
-			<version>1.0.0-SNAPSHOT</version>
+			<version>0.0.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.aries</groupId>
@@ -53,7 +53,7 @@
 		<dependency>
 			<groupId>org.apache.aries</groupId>
 			<artifactId>org.apache.aries.jax.rs.whiteboard</artifactId>
-			<version>1.0.0-SNAPSHOT</version>
+			<version>0.0.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.felix</groupId>

--- a/jax-rs.itests-run/pom.xml
+++ b/jax-rs.itests-run/pom.xml
@@ -12,7 +12,9 @@
 	</parent>
 
 	<artifactId>org.apache.aries.jax.rs.itests-run</artifactId>
-
+    <description>Apache Aries JAX-RS Integration Test Plan</description>
+    <name>Apache Aries JAX-RS Integration Test Plan</name>
+    <version>0.0.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<build>
@@ -48,7 +50,7 @@
 		<dependency>
 			<groupId>org.apache.aries</groupId>
 			<artifactId>org.apache.aries.jax.rs.log4j-configuration</artifactId>
-			<version>1.0.0-SNAPSHOT</version>
+			<version>0.0.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.aries</groupId>

--- a/jax-rs.itests-run/pom.xml
+++ b/jax-rs.itests-run/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>org.apache.aries</groupId>
+		<groupId>org.apache.aries.jax.rs</groupId>
 		<artifactId>org.apache.aries.jax.rs</artifactId>
 		<version>0.0.1-SNAPSHOT</version>
 		<relativePath>..</relativePath>
@@ -43,17 +43,17 @@
 	</build>
 	<dependencies>
 		<dependency>
-			<groupId>org.apache.aries</groupId>
+			<groupId>org.apache.aries.jax.rs</groupId>
 			<artifactId>org.apache.aries.jax.rs.itests</artifactId>
 			<version>0.0.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.aries</groupId>
+			<groupId>org.apache.aries.jax.rs</groupId>
 			<artifactId>org.apache.aries.jax.rs.log4j-configuration</artifactId>
 			<version>0.0.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.aries</groupId>
+			<groupId>org.apache.aries.jax.rs</groupId>
 			<artifactId>org.apache.aries.jax.rs.whiteboard</artifactId>
 			<version>0.0.1-SNAPSHOT</version>
 		</dependency>

--- a/jax-rs.itests/pom.xml
+++ b/jax-rs.itests/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.apache.aries</groupId>
 		<artifactId>org.apache.aries.jax.rs</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>0.0.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.apache.aries.jax.rs.itests</artifactId>

--- a/jax-rs.itests/pom.xml
+++ b/jax-rs.itests/pom.xml
@@ -12,6 +12,9 @@
 	</parent>
 
 	<artifactId>org.apache.aries.jax.rs.itests</artifactId>
+	<description>Apache Aries JAX-RS Integration Tests</description>
+	<name>Apache Aries JAX-RS Integration Tests</name>
+	<version>0.0.1-SNAPSHOT</version>
 
 	<dependencies>
         <dependency>

--- a/jax-rs.itests/pom.xml
+++ b/jax-rs.itests/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>org.apache.aries</groupId>
+		<groupId>org.apache.aries.jax.rs</groupId>
 		<artifactId>org.apache.aries.jax.rs</artifactId>
 		<version>0.0.1-SNAPSHOT</version>
 	</parent>

--- a/jax-rs.log4j-configuration/bnd.bnd
+++ b/jax-rs.log4j-configuration/bnd.bnd
@@ -1,0 +1,1 @@
+Fragment-Host: log4j

--- a/jax-rs.log4j-configuration/pom.xml
+++ b/jax-rs.log4j-configuration/pom.xml
@@ -5,7 +5,7 @@
 >
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.apache.aries</groupId>
+        <groupId>org.apache.aries.jax.rs</groupId>
         <artifactId>org.apache.aries.jax.rs</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>

--- a/jax-rs.log4j-configuration/pom.xml
+++ b/jax-rs.log4j-configuration/pom.xml
@@ -7,9 +7,11 @@
     <parent>
         <groupId>org.apache.aries</groupId>
         <artifactId>org.apache.aries.jax.rs</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.0.1-SNAPSHOT</version>
     </parent>
+
     <artifactId>org.apache.aries.jax.rs.log4j-configuration</artifactId>
-    <packaging>jar</packaging>
     <description>Apache Aries JAX-RS Log4J Configuration Fragment</description>
+    <name>Apache Aries JAX-RS Log4J Configuration Fragment</name>
+    <version>0.0.1-SNAPSHOT</version>
 </project>

--- a/jax-rs.log4j-configuration/pom.xml
+++ b/jax-rs.log4j-configuration/pom.xml
@@ -1,0 +1,15 @@
+<project 
+    xmlns="http://maven.apache.org/POM/4.0.0" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.aries</groupId>
+        <artifactId>org.apache.aries.jax.rs</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>org.apache.aries.jax.rs.log4j-configuration</artifactId>
+    <packaging>jar</packaging>
+    <description>Apache Aries JAX-RS Log4J Configuration Fragment</description>
+</project>

--- a/jax-rs.log4j-configuration/src/main/resources/log4j.properties
+++ b/jax-rs.log4j-configuration/src/main/resources/log4j.properties
@@ -1,0 +1,9 @@
+# Set root logger level to DEBUG and its only appender to A1.
+log4j.rootLogger=ERROR, A1
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+
+# A1 uses PatternLayout.
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n

--- a/jax-rs.whiteboard/pom.xml
+++ b/jax-rs.whiteboard/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.apache.aries</groupId>
         <artifactId>org.apache.aries.jax.rs</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>org.apache.aries.jax.rs.whiteboard</artifactId>
     <packaging>jar</packaging>

--- a/jax-rs.whiteboard/pom.xml
+++ b/jax-rs.whiteboard/pom.xml
@@ -5,7 +5,7 @@
 >
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.apache.aries</groupId>
+        <groupId>org.apache.aries.jax.rs</groupId>
         <artifactId>org.apache.aries.jax.rs</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>

--- a/jax-rs.whiteboard/pom.xml
+++ b/jax-rs.whiteboard/pom.xml
@@ -9,9 +9,12 @@
         <artifactId>org.apache.aries.jax.rs</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
+
     <artifactId>org.apache.aries.jax.rs.whiteboard</artifactId>
-    <packaging>jar</packaging>
     <description>Apache Aries JAX-RS Whiteboard</description>
+    <name>Apache Aries JAX-RS Whiteboard</name>
+    <version>0.0.1-SNAPSHOT</version>
+
     <dependencies>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.aries</groupId>
     <artifactId>org.apache.aries.jax.rs</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
     </build>
     <modules>
         <module>jax-rs.whiteboard</module>
+        <module>jax-rs.log4j-configuration</module>
         <module>jax-rs.itests</module>
         <module>jax-rs.itests-run</module>
         <module>jax-rs.example</module>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.apache.aries</groupId>
+    <groupId>org.apache.aries.jax.rs</groupId>
     <artifactId>org.apache.aries.jax.rs</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>


### PR DESCRIPTION
I've moved everything under a jax.rs group so make sure to purge your .m2. I've also added a logging configuration to eliminate the log4j warnings.